### PR TITLE
Update Ldap#bindAsUser to return itself

### DIFF
--- a/lib/ldap.js
+++ b/lib/ldap.js
@@ -42,9 +42,8 @@ Ldap.prototype._buildUserFilter = function (username) {
 };
 
 Ldap.prototype._buildFilterFromWhere = function (where) {
-    var filters = [];
-    _.forEach(where, function (value, key) {
-        filters.push('(' + key + '=' + value + ')');
+    var filters = _.map(where, function (value, key) {
+        return '(' + key + '=' + value + ')';
     });
     if (filters.length > 1) {
         return '(&' + filters.join('') + ')';

--- a/lib/ldap.js
+++ b/lib/ldap.js
@@ -123,22 +123,23 @@ Ldap.prototype._search = function (filter, options) {
     };
     return this._client.searchAsync(this.baseDn, opts)
         .then(function (searchResult) {
-            var ldapEntries = [];
-            var deferredResults = Promise.defer();
-            searchResult.on('searchEntry', function (entry) {
-                ldapEntries.push(entry.object);
+            return new Promise(function (resolve, reject) {
+                var ldapEntries = [];
+
+                searchResult.on('searchEntry', function (entry) {
+                    ldapEntries.push(entry.object);
+                });
+                searchResult.on('error', function (err) {
+                    return reject(err);
+                });
+                searchResult.on('end', function (endResult) {
+                    if ((ldapEntries) && (endResult.status == 0)) {
+                        return resolve(ldapEntries);
+                    }
+                    return resolve(null);
+                });
             });
-            searchResult.on('error', function (err) {
-                return deferredResults.reject(err);
-            });
-            searchResult.on('end', function (endResult) {
-                if ((ldapEntries) && (endResult.status == 0)) {
-                    return deferredResults.resolve(ldapEntries);
-                }
-                return deferredResults.resolve(null);
-            });
-            return deferredResults.promise;
-        })
+        });
 };
 
 Ldap.prototype.unbind = function () {

--- a/lib/ldap.js
+++ b/lib/ldap.js
@@ -55,7 +55,6 @@ Ldap.prototype._checkBindStatus = function () {
     var self = this;
     return this.bindAsZombie()
         .then(function () {
-            self.unbind();
             return true;
         })
         .catch(function (err) {

--- a/lib/ldap.js
+++ b/lib/ldap.js
@@ -11,7 +11,7 @@ function Ldap(host, options) {
     this.baseDn = options.baseDn || '';
     this.defaultAttributes = options.defaultAttributes || [];
     this.usernameAttribute = options.usernameAttribute || 'cn';
-    this._client = Promise.promisifyAll(ldapjs.createClient({url: host}))
+    this._client = Promise.promisifyAll(ldapjs.createClient({url: host}));
 }
 
 Ldap.prototype.bindAsUser = function (dn, password) {
@@ -30,7 +30,7 @@ Ldap.prototype.buildLdapChangeObject = function (operation, modification) {
     return new ldapjs.Change({
         operation: operation,
         modification: modification
-    })
+    });
 };
 
 Ldap.prototype.buildUserEntry = function (options) {
@@ -59,9 +59,9 @@ Ldap.prototype._checkBindStatus = function () {
             self.unbind();
             return true;
         })
-        .error(function (err) {
+        .catch(function (err) {
             return false;
-        })
+        });
 };
 
 Ldap.prototype.checkStatus = function () {
@@ -75,7 +75,7 @@ Ldap.prototype.checkStatus = function () {
             };
             status.latency = moment().diff(start, 'milliseconds', true) + 'ms';
             return status;
-        })
+        });
 };
 
 Ldap.prototype.createUser = function (dn, options) {
@@ -99,7 +99,7 @@ Ldap.prototype.findUser = function (username) {
                 searchResult = searchResults[0];
             }
             return searchResult;
-        })
+        });
 };
 
 Ldap.getPersonalNameByUsername = function (username) {
@@ -107,7 +107,7 @@ Ldap.getPersonalNameByUsername = function (username) {
     return self.findUser(username)
         .then(function (entry) {
             return self._getPersonalNameByEntry(entry);
-        })
+        });
 };
 
 Ldap.prototype._getPersonalNameByEntry = function (entry) {
@@ -142,7 +142,6 @@ Ldap.prototype._search = function (filter, options) {
         })
 };
 
-
 Ldap.prototype.unbind = function () {
     return this._client.unbindAsync()
         .then(function () {
@@ -150,7 +149,7 @@ Ldap.prototype.unbind = function () {
         })
         .catch(function (err) {
             return false;
-        })
+        });
 };
 
 module.exports = Ldap;

--- a/lib/ldap.js
+++ b/lib/ldap.js
@@ -15,10 +15,7 @@ function Ldap(host, options) {
 }
 
 Ldap.prototype.bindAsUser = function (dn, password) {
-    return this._client.bindAsync(dn, password)
-        .then(function () {
-            return true;
-        })
+    return this._client.bindAsync(dn, password).return(this);
 };
 
 Ldap.prototype.bindAsZombie = function () {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   },
   "main": "./lib/ldap",
   "dependencies": {
-    "bluebird": "^2.2.2",
+    "bluebird": "^2.9.13",
     "ldapjs": "^0.7.1",
-    "lodash": "^2.4.1",
+    "lodash": "^3.5.0",
     "moment": "^2.7.0"
   }
 }


### PR DESCRIPTION
This has a breaking change.

Ldap#bindAsUser now returns a promise that is fulfilled with itself (or is rejected with an error) instead of a boolean reflecting the promise's resolved state.
